### PR TITLE
Changes required for users of Docker for Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ www/
 .log/
 .drush/
 .mysql/
-environment
+docker/environment
+docker/.environment.env
+.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+www/
+.sendmail/
+.log/
+.drush/
+.mysql/
+environment

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="" />
+</component>

--- a/.idea/drupal-docker.iml
+++ b/.idea/drupal-docker.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/drupal-docker.iml" filepath="$PROJECT_DIR$/.idea/drupal-docker.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,88 +1,106 @@
-#  Drupal-Docker Development
+#  Drupal-Docker Development on a Mac
 
-## Why use Docker?
-The first question you could ask would just be this: "Why in the hell should I use docker? I have a development machine running Apache and PHP and Mysql. And now Docker?". Yes you are right. All of these are available on development machines. Let me explain by an example why this could be a problem:
+It is simple to run with the *Docker for Mac* native Docker Server (at least Version 1.12.0-rc4-beta20 as I write). I do not describe development with `docker-machine` which  would then  require *VirtualBox*.  
 
-> I was very curious to update my computer from Kubuntu 15.10 to the latest Kubuntu 16.04. And what did I get? **I got PHP 7.0 and lost my PHP 5.6 installation**. But my servers in the wild (aka Internet) are still running on PHP 5.6! So I decided to remove all the Apache, PHP and Mysql stuff from my machine and installed Docker.  
-
-With Docker you can create containers holding project specific data while they depend on common images. You can even copy whole development environments from one machine to another or only share the settings of a development environment with others. I investigated Docker and created a checklist and some scripts to create Docker-based Drupal development environments and to interact with Docker containers. As I am on Linux, it was developed and tested on Linux. But I am sure it will run on Mac and Windows in a similar way.  
-
-> It is reported that it is simple to run with **Docker for Mac** native Docker Server (at least Version 1.12.0-rc4-beta20) although in this case you may choose not to install *Intellijet*'s Mac **PHPStorm** Docker integration plugin which is aimed at `docker-machine` and so won't offer its full Docker *Tools* benefits.   
 Notes for Mac:    
--  Mac  **PHPStorm** users 1) select a shell script and 2) click `⌃⇧R`  to run it (Shift+control+R and not Ctrl+Shift+F10).
--  *Docker for Mac* does not require *VirtualBox*, it is implemented natively with `macOS HyperKit`.
+
+*  Mac  **PHPStorm** users 1) select a shell script and 2) click `⌃⇧R`  to run it (Shift+control+R and not `⌃⇧R`).
+-  *Docker for Mac* does not require *VirtualBox*, it is implemented natively with *macOS HyperKit*.
 -  `docker-machine` would require *VirtualBox*.
 
-I also use **PhpStorm** (https://www.jetbrains.com/phpstorm/) for development so I describe it from this point of view. Im also sure you can adapt my explanations to other development tools, too.
+This *README* goes into some detail regarding the use of **PhpStorm** (https://www.jetbrains.com/phpstorm/) for development so I describe it from this point of view, but this repo wraps up a  lot of very useful that can be used simply from the command line.
 
-> ### **You don't need to install apache, php or mysql on the computer to run this development environment!** The only requirement is to install Docker (see below).
+So: you definitely don't need  *VirtualBox*; *Apache*; *php*; or *MySQL* installed on your Mac to run this development environment. The only *requirement* is to have *Docker for Mac* and  `homebrew` installed. 
 
 ## What will you get afterwards?
 
-All you need to install is **Docker** and **PhpStorm**! You don't need to install a LAMP-Stack or something else. When you followed this installation instruction, you will get a functional development environment with:
+After you've followed this *README*, you will have a functional development environment with:
  
- * Docker.
+* *Docker*.
  
- * PhpStorm.
+* *PhpStorm*.
  
- * Apache2 with PHP 5.6 / Mysql, and/or Apache2 with PHP 7.0 / Mysql (in a Docker container). It will also contain a faked sendmail script so you can test sending mails out of your drupal site.
+* *Apache2* with *PHP 5.6* / *Mysql*, and/or *Apache2* with *PHP 7.0* / *Mysql* (in a *Docker* container). It will also contain a faked `sendmail` script so you can test sending mails out of your *Drupal* site.
  
- * Drush (in a separate Docker container, thus independent of the PHP-version in the Apache container).
+* *Drush* (in a separate *Docker* container, thus independent of the PHP-version in the *Apache* container).
  
- * Drupal console (in a separate Docker container) to be used in conjunction with Drupal 8.
+* *Drupal console* (in a separate *Docker* container) to be used in conjunction with *Drupal 8*.
  
- * Node.js, npm and gulp on the fly (managed by Docker). You need gulp if you develop a Zen-theme.
+*  *Node.js*, *npm* and *gulp* on the fly (managed by *Docker*) should you need `gulp` to compile your *SASS* etc.
  
- * SASS/SCSS compilation on the fly (managed by Docker).
+* *SASS/SCSS* compilation on the fly (managed by *Docker* and *PHPStorm*).
  
- You can extend the list as you like. Use the provides scripts as templates.
+The provided scripts can be used as templates for further tasks as you wish.
 
 ## PhpStorm prerequisites
 
-To work with PhpStorm efficiently, some Plugins must be installed: To install the Docker plugin go to File→Settings→Plugins and **activate the Docker plugin**. Here you can also **activate the Drupal support plugin** and the **BashSupport plugin**, if not already active. 
+To integrate nicely with *PhpStorm*, some Plugins must be installed: To
+install the *Docker Integration* plugin go to
+*PHPStorm→Preferences→Plugins→Install JetBrains Plugins* and choose and
+activate the Docker plugin. Here you can also activate the *Drupal*
+support plugin and the *BashSupport* plugin, if not already active.
 
 ## How to install Docker
 
-You can find several tutorials on the web, especially on the Docker website, how to install Docker. I followed this (https://docs.docker.com/engine/installation/linux/ubuntulinux/) and was very happy with it. The advantage of a Linux-based system is, that it does not need docker-machine, boot2docker, virtualbox and so on ☺.  
+This fork is adapted (with only *very* few minor changes to `peperoni60`'s base) to work with *Docker for Mac*. So, if you're doing your development and running *PHPStorm* on Linux you'll find really good Linux details in [his original repo](https://github.com/peperoni60/drupal-docker). But for the fork you're now reading, go to the [Docker for Mac](https://docs.docker.com/docker-for-mac/) page.
 
-As I wanted to use docker-compose, too, I tried to install it from the repositories. But I didn't get the right version, which allowed my to write version 2 compliant docker-compose.yml files. So what to do? The solution is so simple: Use Docker to run docker-compose. That means: Download a script that runs docker-compose in a docker container. You'll find the installation instructions here: https://docs.docker.com/compose/install/#install-as-a-container On Linux run the commands as sudo!
+### To add a Docker server in PhpStorm on your Mac
 
-> To add a Docker server in PhpStorm on Linux, use **`unix:///var/run/docker.sock`** as API URL.
+-  Install the JetBrains Docker Integration plugin (as above)
+-  `brew install coreutils socat`  
+    We use `socat` as [a work around](https://forums.docker.com/t/worked-around-docker-http-s-api-no-longer-available-in-beta9/10474) to listen on the Unix socket for interprocess communicarion between *PHPStorm*
+ and *Docker*.    We use `coreultils` to use the *Gnu* `env` command rather than the *Darwin* `env`: they're quite different.  
+-  `socat TCP-LISTEN:2376,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock` in a _Terminal_ window and leave it running.
+    
+-  Go to  *PHPStorm→Preferences→Build Execution Deployment→Docker* and click **+** to define a _Docker Server_.
+    -  Name the server
+    -  Specify `unix:/http://localhost:2376` as  the _API URL_.
+    -  Specify `/Users/<my Mac user>/.docker/machine/certs` as the
+       _Certificates folder_ 
+    -  Leave the default value `docker-compose` as is
 
-> Sometimes this kind of docker-compose has problems to run when using the PhpStorm built-in Docker tools. But that doesn't matter as I wrote scripts to run docker-compose. And these scripts integrate well with PhpStorm. See below.
 
 ## Overview
 
 These are the minimal steps to take if you set up and work with a project:
 
-1. Create a new project (**once** per project)
+1. Build Images (once **per Mac**)
 
-2. Build Images (**once per computer**)
+2. Create a new project (once **per project**)
 
-3. Setup the environment (**once** per project)
+3. Setup the environment (once **per project**)
 
-4. Create and start the containers (**once** per project)
+4. Create and start the containers (once **per project**)
 
-5. Install Drupal and a drupal site (**once** per project)
+5. Install Drupal and a drupal site (once **per project**)
 
 6. Start/Stop the containers (regularly, as needed)
 
 
 ## Set up a drupal development project with Docker
 
-This instructions can help you to set up a drupal development project with one project-specific container for Apache/PHP, one project specific container for Mysql. Both containers run in a project-specific network. All the project files (PHP, other files, Mysql database files) will be stored locally (that means: on the host's file system) and not within the containers. Thus the containers could be deleted and recreated as needed without losing data.
+This instructions guide you through setting up a _Drupal_ development project with one project-specific container for Apache/PHP, one project specific container for Mysql. Both containers run in a project-specific network. All the project files (PHP, other files, Mysql database files) will be stored locally (that means: on the host's file system) and not within the containers. Thus the containers could be deleted and recreated as needed without losing data.
 
-To use drush and drupal console you will set up separate images and these images are used by docker to create containers on the fly when needed. 
-> The reason why you set up your own images is: you need to volume the drush and drupal console settings (.drush, .console) and, as they run as root inside, change the default umode 022 (read, write by owner, read only by others) to 000 (read/write to all). Thus the user www-data in the apache container is able to write into directories that are not owned by www-data. This is not a security issue, as we work locally and use private networks only. 
+To use _drush_ and _drupal console_ we will set up separate images and these images are used by `docker` to create containers on the fly when needed. 
+> The reason why you set up your own images is: you need to volume the
+> _drush_ and _drupal console_ settings (`.drush`; `.console` directories) and, as
+> they run as root inside, change the default umode 022 (read, write by
+> owner, read only by others) to 000 (read/write to all). Thus the user
+> www-data in the apache container is able to write into directories
+> that are not owned by www-data. This is not a security issue, as we
+> work locally and use private networks only.
 
 **So, let's go!**
  
-> The following instructions use *italic* text as placeholders. These
-> placeholders must be replaced by real values when following the instructions.
+> In this section the following instructions use **_bold italic_** text as
+> placeholders. Replace these placeholders with real values when
+> following the instructions.
 
 * Create a new empty project *Project* in PhpStorm (File→New Project→Empty Project).
 
-* clone (or download) https://github.com/peperoni60/drupal-docker into this *Project*.
+* Clone or download
+  [the repo who's _README_ we're reading](https://github.com/iainhouston/drupal-docker)
+  into this *Project*.
 
 * We will get this directory structure:
     * *Project*
@@ -97,13 +115,13 @@ To use drush and drupal console you will set up separate images and these images
             * tmp
             * private
                
-    * The name of ***Project*** can be chosen as you like.
+    * The name of **_Project_** can be chosen as you like.
     
-    * **docker** contains build files and utilities for Docker
+    * _docker_ contains build files and utilities for Docker
     
-    * **www** and subsequent directories will be created automatically during installation
+    * _www_ and subsequent directories will be created automatically during installation
     
-        * **docroot** is the root folder for Apache. Here all PHP-files and user created files will reside.
+        * _docroot_ is the root folder for Apache. Here all PHP-files and user created files will reside.
         
         * **tmp** is a directory for temporary files. It can be used as tmp-directory in Drupal (`admin/config/media/file-system`, use `../tmp`)
         
@@ -114,7 +132,7 @@ To use drush and drupal console you will set up separate images and these images
 ### Build the images
 
 If this is your first project at all, you should build the images we need.
-In PhpStorm run the scripts **build.sh** in docker/drupalconsole, docker/drush, docker/node.js, docker/Ubuntu_15.10, docker/Ubuntu_16.04 (mark `build.sh`, then press Ctrl+Shift+F10). **These Images will be used in this project and reused in later projects**.
+In PhpStorm run the scripts **build.sh** in docker/drupalconsole, docker/drush, docker/node.js, docker/Ubuntu_15.10, docker/Ubuntu_16.04 (select `build.sh`, then press `⌃⇧R`). These Images will be used in this project and reused in later projects.
 
 ### Set up the environment
 
@@ -163,7 +181,7 @@ Now go into the "docker" folder and copy **sample.environment** to **environment
 
 Now you can create the containers and the network for this project. 
 
-* In PhpStorm start the script **startup.sh** in the "docker" folder (mark `startup.sh`, then press Ctrl+Shift+F10). When the containers are running (you can control it in PhpStorm by clicking on the Docker-tab at the lower left border) you can take the next steps.
+* In PhpStorm start the script **startup.sh** in the "docker" folder (select `startup.sh`, then press `⌃⇧R`). When the containers are running (you can control it in PhpStorm by clicking on the Docker-tab at the lower left border) you can take the next steps.
 > **Tip**  
 In PhpStorm you can now easily add a run configuration with startup.sh. From the "Run" menu select "Edit Configurations", select the entry "startup.sh" and save it (click on the diskette-icon). If you then go to File→Settings→Tools→Startup Tasks you can add startup.sh to the list to start/stop the containers when you open/close the PhpStorm project. 
 
@@ -179,16 +197,20 @@ In PhpStorm you can now easily add a run configuration with startup.sh. From the
 ### Install Drupal website with default values
 
 
-To install a Drupal website with default values execute the script **drush-si.sh** in PhpStorm (mark `drush-si.sh`, then press Ctrl+Shift+F10). This will download Drupal if necessary, create a database if necessary, install Drupal within this database and open the site in your browser. 
+To install a Drupal website with default values execute the script
+**drush-si.sh** in PhpStorm (select `drush-si.sh`, then press `⌃⇧R` to
+run it). This will download Drupal if necessary, create a database if
+necessary, install Drupal within this database and open the site in your
+browser.
 > To manually open your new site point your browser at “http://*APACHE_HOSTNAME*” (or “http://*APACHE_IP*” if you could not change /etc/hosts).  
 But point to "localhost" when running *Docker for Mac* which does not offer a mapping of `docker-composer`'s `ipv4_address` in the Docker Server. Because of the way networking is implemented in *Docker for Mac*, you cannot see a docker0 interface in macOS. This interface is actually within *HyperKit*.
      
 ### Install Drupal with custom values
 
-To download Drupal 7 or Drupal 8, execute the script **download_druspl7.sh** or **download_drupal8.sh** in PhpStorm (mark the script, then press Ctrl+Shift+F10). This will prepare the docroot with writable "custom" folders in the "modules" and the "themes" folder.
+To download Drupal 7 or Drupal 8, execute the script **download_druspl7.sh** or **download_drupal8.sh** in PhpStorm (select the script, then press `⌃⇧R`). This will prepare the docroot with writable "custom" folders in the "modules" and the "themes" folder.
 > **All files and directories in www/docroot will be deleted!**
 
-* You want to use mysql as the database server have to create the database for Drupal by running the script **create_mysql_drupal_db.sh** in PhpStorm (mark `create_mysql_drupal_db.sh`, then press Ctrl+Shift+F10). **A database with same name will be dropped and recreated!**. If you want to use sqlite yu can skip this step.
+* You want to use mysql as the database server have to create the database for Drupal by running the script **create_mysql_drupal_db.sh** in PhpStorm (select `create_mysql_drupal_db.sh`, then press `⌃⇧R`). **A database with same name will be dropped and recreated!**. If you want to use sqlite yu can skip this step.
     > **Tip**
     > To interact with the terminal window you have to click into it until you see a blinking cursor!
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 It is simple to run with the *Docker for Mac* native Docker Server (at least Version 1.12.0-rc4-beta20 as I write). I do not describe development with `docker-machine` which  would then  require *VirtualBox*.  
 
-Notes for Mac:    
-
-*  Mac  **PHPStorm** users 1) select a shell script and 2) click `⇧^R`  to run it (Shift+control+R and not `⇧^R`).
--  *Docker for Mac* does not require *VirtualBox*, it is implemented natively with *macOS HyperKit*.
--  `docker-machine` would require *VirtualBox*.
-
 This *README* goes into some detail regarding the use of **PhpStorm** (https://www.jetbrains.com/phpstorm/) for development so I describe it from this point of view, but this repo wraps up a  lot of very useful that can be used simply from the command line.
 
 So: you definitely don't need  *VirtualBox*; *Apache*; *php*; or *MySQL* installed on your Mac to run this development environment. The only *requirement* is to have *Docker for Mac* and  `homebrew` installed. 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ The first question you could ask would just be this: "Why in the hell should I u
 With Docker you can create containers holding project specific data while they depend on common images. You can even copy whole development environments from one machine to another or only share the settings of a development environment with others. I investigated Docker and created a checklist and some scripts to create Docker-based Drupal development environments and to interact with Docker containers. As I am on Linux, it was developed and tested on Linux. But I am sure it will run on Mac and Windows in a similar way.  
 
 > It is reported that it is simple to run with **Docker for Mac** native Docker Server (at least Version 1.12.0-rc4-beta20) although in this case you may choose not to install *Intellijet*'s Mac **PHPStorm** Docker integration plugin which is aimed at `docker-machine` and so won't offer its full Docker *Tools* benefits.   
-Mac  **PHPStorm** users select a shell script and click `⌃⇧R` (Shift+control+R) to run it.
+Notes for Mac:    
+-  Mac  **PHPStorm** users 1) select a shell script and 2) click `⌃⇧R`  to run it (Shift+control+R and not Ctrl+Shift+F10).
+-  *Docker for Mac* does not require *VirtualBox*, it is implemented natively with `macOS HyperKit`.
+-  `docker-machine` would require *VirtualBox*.
 
 I also use **PhpStorm** (https://www.jetbrains.com/phpstorm/) for development so I describe it from this point of view. Im also sure you can adapt my explanations to other development tools, too.
 
@@ -170,13 +173,15 @@ In PhpStorm you can now easily add a run configuration with startup.sh. From the
     sudo ./addhost.sudo.sh
     ```
     This will do the job.
-    
+    (Not required for *Docker for Mac*: see below.)
+
 
 ### Install Drupal website with default values
 
 
 To install a Drupal website with default values execute the script **drush-si.sh** in PhpStorm (mark `drush-si.sh`, then press Ctrl+Shift+F10). This will download Drupal if necessary, create a database if necessary, install Drupal within this database and open the site in your browser. 
-> To manually open your new site point your browser at “http://*APACHE_HOSTNAME*” (or “http://*APACHE_IP*” if you could not change /etc/hosts).
+> To manually open your new site point your browser at “http://*APACHE_HOSTNAME*” (or “http://*APACHE_IP*” if you could not change /etc/hosts).  
+But point to "localhost" when running *Docker for Mac* which does not offer a mapping of `docker-composer`'s `ipv4_address` in the Docker Server. Because of the way networking is implemented in *Docker for Mac*, you cannot see a docker0 interface in macOS. This interface is actually within *HyperKit*.
      
 ### Install Drupal with custom values
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The first question you could ask would just be this: "Why in the hell should I u
 
 With Docker you can create containers holding project specific data while they depend on common images. You can even copy whole development environments from one machine to another or only share the settings of a development environment with others. I investigated Docker and created a checklist and some scripts to create Docker-based Drupal development environments and to interact with Docker containers. As I am on Linux, it was developed and tested on Linux. But I am sure it will run on Mac and Windows in a similar way.  
 
+> It is reported that it is simple to run with **Docker for Mac** native Docker Server (at least Version 1.12.0-rc4-beta20) although in this case you may choose not to install *Intellijet*'s Mac **PHPStorm** Docker integration plugin which is aimed at `docker-machine` and so won't offer its full Docker *Tools* benefits.   
+Mac  **PHPStorm** users select a shell script and click `⌃⇧R` (Shift+control+R) to run it.
+
 I also use **PhpStorm** (https://www.jetbrains.com/phpstorm/) for development so I describe it from this point of view. Im also sure you can adapt my explanations to other development tools, too.
 
 > ### **You don't need to install apache, php or mysql on the computer to run this development environment!** The only requirement is to install Docker (see below).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It is simple to run with the *Docker for Mac* native Docker Server (at least Ver
 
 Notes for Mac:    
 
-*  Mac  **PHPStorm** users 1) select a shell script and 2) click `⌃⇧R`  to run it (Shift+control+R and not `⌃⇧R`).
+*  Mac  **PHPStorm** users 1) select a shell script and 2) click `⇧^R`  to run it (Shift+control+R and not `⇧^R`).
 -  *Docker for Mac* does not require *VirtualBox*, it is implemented natively with *macOS HyperKit*.
 -  `docker-machine` would require *VirtualBox*.
 
@@ -54,7 +54,7 @@ This fork is adapted (with only *very* few minor changes to `peperoni60`'s base)
     
 -  Go to  *PHPStorm→Preferences→Build Execution Deployment→Docker* and click **+** to define a _Docker Server_.
     -  Name the server
-    -  Specify `unix:/http://localhost:2376` as  the _API URL_.
+    -  Specify `http://localhost:2376` as  the _API URL_.
     -  Specify `/Users/<my Mac user>/.docker/machine/certs` as the
        _Certificates folder_ 
     -  Leave the default value `docker-compose` as is
@@ -79,28 +79,24 @@ These are the minimal steps to take if you set up and work with a project:
 
 ## Set up a drupal development project with Docker
 
-This instructions guide you through setting up a _Drupal_ development project with one project-specific container for Apache/PHP, one project specific container for Mysql. Both containers run in a project-specific network. All the project files (PHP, other files, Mysql database files) will be stored locally (that means: on the host's file system) and not within the containers. Thus the containers could be deleted and recreated as needed without losing data.
+These instructions guide us through setting up a _Drupal_ development project with the following character:  
+
+-  One project-specific container for _Apache/PHP_, 
+-  One project specific container for _Mysql_. 
+-  Both containers run in a project-specific network. 
+-  All the project files (_PHP_, other files, _Mysql_ database files) will be stored locally (that means: on the host's file system) and not within the containers. Thus the containers could be deleted and recreated as needed without losing data.
+
 
 To use _drush_ and _drupal console_ we will set up separate images and these images are used by `docker` to create containers on the fly when needed. 
-> The reason why you set up your own images is: you need to volume the
-> _drush_ and _drupal console_ settings (`.drush`; `.console` directories) and, as
-> they run as root inside, change the default umode 022 (read, write by
-> owner, read only by others) to 000 (read/write to all). Thus the user
-> www-data in the apache container is able to write into directories
-> that are not owned by www-data. This is not a security issue, as we
-> work locally and use private networks only.
+> The reason why we set up your own images is: we need to volume the _drush_ and _drupal console_ settings (in the `.drush`; `.console` directories) and, as they run as `root` inside, we change the default `umode 022` (read, write by owner, read only by others) to `000` (read/write to all).
+ Thus the user `www-data` in the _apache_ container is able to write into directories that are not owned by `www-data`. This is not a security issue, as we work locally and use private networks only.
 
 **So, let's go!**
  
-> In this section the following instructions use **_bold italic_** text as
-> placeholders. Replace these placeholders with real values when
-> following the instructions.
+* Create a new empty project directory *Project* in PhpStorm (File→New Project→Empty Project) using your choice of value for *Project*.
 
-* Create a new empty project *Project* in PhpStorm (File→New Project→Empty Project).
-
-* Clone or download
-  [the repo who's _README_ we're reading](https://github.com/iainhouston/drupal-docker)
-  into this *Project*.
+* Clone or download   [the repo who's _README_ we're reading](https://github.com/iainhouston/drupal-docker)
+  into the *Project* directory.
 
 * We will get this directory structure:
     * *Project*
@@ -114,31 +110,41 @@ To use _drush_ and _drupal console_ we will set up separate images and these ima
             * docroot
             * tmp
             * private
-               
-    * The name of **_Project_** can be chosen as you like.
-    
+                   
     * _docker_ contains build files and utilities for Docker
     
     * _www_ and subsequent directories will be created automatically during installation
     
         * _docroot_ is the root folder for Apache. Here all PHP-files and user created files will reside.
         
-        * **tmp** is a directory for temporary files. It can be used as tmp-directory in Drupal (`admin/config/media/file-system`, use `../tmp`)
+        * _tmp_ is a directory for temporary files. It can be used as tmp-directory in Drupal (`admin/config/media/file-system`, use `../tmp`)
         
-        * **private** is a directory for holding the private files in Drupal, but outside the web root (`admin/config/media/file-system`, use `../private`, in D8: settings.php). If you install backup_migrate, you will need it!
+        * _private_ is a directory for holding the private files in _Drupal_, but outside the web root (`admin/config/media/file-system`, use `../private`, in D8: settings.php). If you install the Drupal `backup_migrate`module , you will need it.
     
-    * Following the subsequent steps Docker will create additional directories ***Project*/.log** and ***Project*/.mysql** to hold Apache log files and the Mysql database files, ***Project*/.console** to hold the settings for the Drupal console, ***Project*/.drush** to hold the settings for Drush and ***Project*/.sendmail** to collect the mails sent by Drupal (sendmail will be faked)
+    * Following subsequent steps Docker will create additional directories 
+        * _Project/_.log and _Project/_.mysql to hold _Apache_ log files and the _Mysql_ database files, 
+        * _Project/_.console to hold the settings for the _drupal console_, 
+        * _Project/_.drush to hold the settings for _Drush_ and
+        * _Project/_.sendmail to collect the mails sent by Drupal (`sendmail` will be faked)
 
 ### Build the images
 
-If this is your first project at all, you should build the images we need.
-In PhpStorm run the scripts **build.sh** in docker/drupalconsole, docker/drush, docker/node.js, docker/Ubuntu_15.10, docker/Ubuntu_16.04 (select `build.sh`, then press `⌃⇧R`). These Images will be used in this project and reused in later projects.
+Several of the _Docker_ images are shared across multiple projects. For our first project, we'll build the images we need.
+In _PhpStorm_ run the scripts `build.sh` in  each of the following directories:
+
+-  `docker/drupalconsole`; 
+-  `docker/drush`; 
+-  `docker/node.js`; 
+-  `docker/Ubuntu_15.10`; 
+-  `docker/Ubuntu_16.04` 
+
+In each case select `build.sh`, then press `⇧^R`). These Images will be used in this project and reused in later projects.
 
 ### Set up the environment
 
-Now go into the "docker" folder and copy **sample.environment** to **environment**. This file holds environment variables to pass to docker during compose and aliases to be used on the command line:     
+Now go into the `docker` directory and copy `sample.environment` to `environment`. This file holds environment variables to pass to `docker-compose`, and aliases to be used on the command line as follows: 
 
-> Necessary changes are annotated with TODOs in the environment file! 
+> Necessary changes are annotated with **TODO**s in the `environment` file 
 
 * **PROJECT_NAME** is used to build the names of Images, Containers and Networks. You should supply a name that is unique within the your machine. It must consist of lower case letters and underscores.
 
@@ -150,11 +156,13 @@ Now go into the "docker" folder and copy **sample.environment** to **environment
     
     * my/ubuntu:16.04: Apache 2 with PHP 7.0
     
-* **APACHE_HOSTNAME** is the domain name, which could be later added to /etc/hosts. You can then us this name to open your website in a browser. **The name has to be unique within the Docker host!**
+* **APACHE_HOSTNAME** is the domain name, which could be later added to `/etc/hosts`. You can then us this name to open your website in a browser.  
+> The name has to be unique within the Docker host! 
+> It may be  possible to route an IP address to the *Docker for Mac* Server but not with the "bridge" driver as used here. Watch this space! In the meantime use *localhost*
 
 * **MYSQL_NAME** is the name of the container to be created for Mysql.
 
-* **MYSQL_IMAGE** is the name of the image to create the Mysql container of. Normally it is not necessary to modify this entry.
+* **MYSQL_IMAGE** is the name f the image to create the Mysql container of. Normally it is not necessary to modify this entry.
 
 * **MYSQL_HOSTNAME** is the host name of the Mysql container which could be later added to /etc/hosts. In PhpStorm you can then connect to the database using this name instead of using the IP address (remember: Mysql is not running on the local host and we do not redirect ports). 
 
@@ -181,7 +189,7 @@ Now go into the "docker" folder and copy **sample.environment** to **environment
 
 Now you can create the containers and the network for this project. 
 
-* In PhpStorm start the script **startup.sh** in the "docker" folder (select `startup.sh`, then press `⌃⇧R`). When the containers are running (you can control it in PhpStorm by clicking on the Docker-tab at the lower left border) you can take the next steps.
+* In PhpStorm start the script **startup.sh** in the "docker" folder (select `startup.sh`, then press `⇧^R`). When the containers are running (you can control it in PhpStorm by clicking on the Docker-tab at the lower left border) you can take the next steps.
 > **Tip**  
 In PhpStorm you can now easily add a run configuration with startup.sh. From the "Run" menu select "Edit Configurations", select the entry "startup.sh" and save it (click on the diskette-icon). If you then go to File→Settings→Tools→Startup Tasks you can add startup.sh to the list to start/stop the containers when you open/close the PhpStorm project. 
 
@@ -198,7 +206,7 @@ In PhpStorm you can now easily add a run configuration with startup.sh. From the
 
 
 To install a Drupal website with default values execute the script
-**drush-si.sh** in PhpStorm (select `drush-si.sh`, then press `⌃⇧R` to
+**drush-si.sh** in PhpStorm (select `drush-si.sh`, then press `⇧^R` to
 run it). This will download Drupal if necessary, create a database if
 necessary, install Drupal within this database and open the site in your
 browser.
@@ -207,10 +215,10 @@ But point to "localhost" when running *Docker for Mac* which does not offer a ma
      
 ### Install Drupal with custom values
 
-To download Drupal 7 or Drupal 8, execute the script **download_druspl7.sh** or **download_drupal8.sh** in PhpStorm (select the script, then press `⌃⇧R`). This will prepare the docroot with writable "custom" folders in the "modules" and the "themes" folder.
+To download Drupal 7 or Drupal 8, execute the script **download_druspl7.sh** or **download_drupal8.sh** in PhpStorm (select the script, then press `⇧^R`). This will prepare the docroot with writable "custom" folders in the "modules" and the "themes" folder.
 > **All files and directories in www/docroot will be deleted!**
 
-* You want to use mysql as the database server have to create the database for Drupal by running the script **create_mysql_drupal_db.sh** in PhpStorm (select `create_mysql_drupal_db.sh`, then press `⌃⇧R`). **A database with same name will be dropped and recreated!**. If you want to use sqlite yu can skip this step.
+* You want to use mysql as the database server have to create the database for Drupal by running the script **create_mysql_drupal_db.sh** in PhpStorm (select `create_mysql_drupal_db.sh`, then press `⇧^R`). **A database with same name will be dropped and recreated!**. If you want to use sqlite yu can skip this step.
     > **Tip**
     > To interact with the terminal window you have to click into it until you see a blinking cursor!
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,9 @@ services:
   apache2:
     container_name: $APACHE_NAME
     image: $APACHE_IMAGE
+    ports:
+      - 80:80
+      - 443:443
     volumes:
       - ../www:/var/www
       - ../.log:/var/log/apache2

--- a/docker/functions
+++ b/docker/functions
@@ -142,6 +142,10 @@ alias drupal=drupal # if scripts require an alias
 alias node=node # if scripts require an alias
 alias npm=npm # if scripts require an alias
 alias gulp=gulp # if scripts require an alias
+alias env=genv # Use Gnu 's `env` for this project
+
+# workaround for Mac phpstorm Docker Integration plugin's API URL: http://localhost:2376
+alias socat="socat TCP-LISTEN:2376,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock"
 
 # prepare the directories to set ownership and access rights and to avoid scripts complaining about missing folders
 old_umask=$(umask)

--- a/docker/sample.environment
+++ b/docker/sample.environment
@@ -43,7 +43,8 @@ export APACHE_IP=${subnet}.100
 export MYSQL_IP=${subnet}.101
 
 # Echo the values set above to create an environment file for use by Docker:
-env --unset=PWD --unset=SHLVL --unset=_
+unset PWD SHLVL _
+env 
 
 # Site install defaults
 # ----------------------

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
 # create the environment file for Docker
-env -i ./environment | sort > ./.environment.env
+env -i ./environment | sort > .environment.env
+
+echo "COMPOSE_OPTIONS ============================"
+cat .environment.env
 
 # load functions and environment variables
 . functions
 
 # start docker containers
-export COMPOSE_OPTIONS="--env-file=./.environment.env"
+export COMPOSE_OPTIONS="--env-file=.environment.env"
 docker-compose --project-name "$PROJECT_NAME" up
 
 # cleanup

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # create the environment file for Docker
-env -i environment | sort > .environment.env
+env -i ./environment | sort > ./.environment.env
 
 # load functions and environment variables
 . functions
 
 # start docker containers
-export COMPOSE_OPTIONS="--env-file=.environment.env"
+export COMPOSE_OPTIONS="--env-file=./.environment.env"
 docker-compose --project-name "$PROJECT_NAME" up
 
 # cleanup


### PR DESCRIPTION
There were a few differences in the way Darwin `env` works and Gnu `env` so I have used `env` in a way that works on both.    
-  _Docker for Mac_ does not expose `docker-compose`s `ipv4_address` so you browse `localhost`. This limitation is outweighed in my opinion by the simplicity of  _Docker for Mac_. So in the interests of simplicity I went for _Docker for Mac_ rather than `docker-machine` and _VirtualBox_ nonsense.
-   _Docker for Mac_ exposes but does not publish `Dockerfile`s ports so you need to have `docker-compose` explicitly publish them with its `ports`.
